### PR TITLE
Allow just-in-time page pre-generation with a fallback.

### DIFF
--- a/components/FallbackContainer.js
+++ b/components/FallbackContainer.js
@@ -1,0 +1,13 @@
+import Container from "./Container";
+
+export default function FallbackContainer() {
+  return (
+    <Container>
+      <div className="flex items-center justify-center min-h-[calc(100vh-6.75rem)]">
+        <h2 className="font-primary text-branding-accent-secondary animate-pulse text-2xl">
+          Loading...
+        </h2>
+      </div>
+    </Container>
+  );
+}

--- a/pages/menus/[menuId].js
+++ b/pages/menus/[menuId].js
@@ -1,13 +1,20 @@
 import { useState } from "react";
+import { useRouter } from "next/router";
 import { transformData, fetchData } from "@/lib/data-handler";
 
+import FallbackContainer from "@/components/FallbackContainer";
 import MenuContainer from "@/components/MenuContainer";
 import DisplayCard from "@/components/DisplayCard";
 
 // TODO: both this page and `/menus` share the exact same similarity
 // find out how to eliminate and prevent code duplication
 export default function MenuPage({ selectedMenu, menuList }) {
+  const router = useRouter();
   const [searchValue, setSearchValue] = useState("");
+
+  if (router.isFallback) {
+    return <FallbackContainer />;
+  }
 
   const onSearch = (lowerCasedValue) => {
     setSearchValue(lowerCasedValue);
@@ -44,7 +51,7 @@ export async function getStaticPaths() {
 
   return {
     paths: menuIds,
-    fallback: false,
+    fallback: true,
   };
 }
 

--- a/pages/products/[productId].js
+++ b/pages/products/[productId].js
@@ -1,10 +1,25 @@
 import { useState } from "react";
+import { useRouter } from "next/router";
 import { fetchData, transformData } from "@/lib/data-handler";
 
+import Container from "@/components/Container";
 import MenuContainer from "@/components/MenuContainer";
 
 export default function ProductPage({ menuList, productDetail }) {
+  const router = useRouter();
   const [productQuantity, setProductQuantity] = useState(1);
+
+  if (router.isFallback) {
+    return (
+      <Container>
+        <div className="flex items-center justify-center min-h-[calc(100vh-6.75rem)]">
+          <h2 className="font-primary text-branding-accent-secondary animate-pulse text-2xl">
+            Loading...
+          </h2>
+        </div>
+      </Container>
+    );
+  }
 
   const quantityButtonHandler = (action) => {
     return () => {
@@ -105,15 +120,17 @@ export async function getStaticPaths() {
     ({ id }) => ({ params: { productId: id } })
   );
 
+  console.log("ProductPage: getStaticPaths -> successfully generate pages");
   return {
     paths: productIds,
-    fallback: false,
+    fallback: true,
   };
 }
 
 export async function getStaticProps(context) {
   const data = await fetchData();
   if (!data) {
+    console.log("ProductPage: getStaticProps -> fetched empty data");
     return { notFound: true };
   }
 
@@ -123,6 +140,9 @@ export async function getStaticProps(context) {
     ({ id }) => context.params.productId === id
   );
   if (!productDetail) {
+    console.log(
+      `ProductPage: getStaticProps -> couldn't find the product detail of ${context.params.productId}`
+    );
     return { notFound: true };
   }
 
@@ -132,6 +152,9 @@ export async function getStaticProps(context) {
       : { id, displayName };
   });
 
+  console.log(
+    "ProductPage: getStaticProps -> successfully deliver props to the page"
+  );
   return {
     props: { menuList, productDetail },
     revalidate: 60,

--- a/pages/products/[productId].js
+++ b/pages/products/[productId].js
@@ -2,23 +2,15 @@ import { useState } from "react";
 import { useRouter } from "next/router";
 import { fetchData, transformData } from "@/lib/data-handler";
 
-import Container from "@/components/Container";
 import MenuContainer from "@/components/MenuContainer";
+import FallbackContainer from "@/components/FallbackContainer";
 
 export default function ProductPage({ menuList, productDetail }) {
   const router = useRouter();
   const [productQuantity, setProductQuantity] = useState(1);
 
   if (router.isFallback) {
-    return (
-      <Container>
-        <div className="flex items-center justify-center min-h-[calc(100vh-6.75rem)]">
-          <h2 className="font-primary text-branding-accent-secondary animate-pulse text-2xl">
-            Loading...
-          </h2>
-        </div>
-      </Container>
-    );
+    return <FallbackContainer />;
   }
 
   const quantityButtonHandler = (action) => {
@@ -120,7 +112,6 @@ export async function getStaticPaths() {
     ({ id }) => ({ params: { productId: id } })
   );
 
-  console.log("ProductPage: getStaticPaths -> successfully generate pages");
   return {
     paths: productIds,
     fallback: true,
@@ -130,7 +121,6 @@ export async function getStaticPaths() {
 export async function getStaticProps(context) {
   const data = await fetchData();
   if (!data) {
-    console.log("ProductPage: getStaticProps -> fetched empty data");
     return { notFound: true };
   }
 
@@ -140,9 +130,6 @@ export async function getStaticProps(context) {
     ({ id }) => context.params.productId === id
   );
   if (!productDetail) {
-    console.log(
-      `ProductPage: getStaticProps -> couldn't find the product detail of ${context.params.productId}`
-    );
     return { notFound: true };
   }
 
@@ -152,9 +139,6 @@ export async function getStaticProps(context) {
       : { id, displayName };
   });
 
-  console.log(
-    "ProductPage: getStaticProps -> successfully deliver props to the page"
-  );
   return {
     props: { menuList, productDetail },
     revalidate: 60,


### PR DESCRIPTION
Some pages (especially: `/menus/[menuId]` and `/products/[productId]`) has a fully dynamic data and it would be a cumbersome if we pregenerate all pages whenever a new item added.

By setting `fallback: true` in our `getStaticPaths()` method, we will pre-generate the page that does not exists in our build (or cache) just in time when a new request to that particular page arrived.

I've tried this approach before, but it seems doesn't work if we provide an empty array to the `paths` property.